### PR TITLE
Hide current speaker from the background

### DIFF
--- a/gridview-content.js
+++ b/gridview-content.js
@@ -166,6 +166,11 @@ function ensureStylesApplied() {
 .GhN39b {
   z-index: 11;
 }
+
+/* Hide current speaker from the background */
+.qMwJZe {
+  visibility: hidden;
+}
     `;
 
   const elem = document.createElement('style');


### PR DESCRIPTION
Current speaker was shown even when the grid layout was enabled.
It was especially visible when there were 3 attendees.

Closes #2